### PR TITLE
user issues fixed

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,10 +9,10 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     # For additional fields in app/views/devise/registrations/new.html.erb
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :phone, :suburb, :dob, :partner_email])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :phone, :suburb, :dob, :partner_email, :avatar])
 
     # For additional in app/views/devise/registrations/edit.html.erb
-    devise_parameter_sanitizer.permit(:account_update, keys: [:first_name, :last_name, :phone, :suburb, :dob])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:first_name, :last_name, :phone, :suburb, :dob, :avatar])
   end
 
   private

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :configure_sign_up_params, only: [:create]
+  before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+   def configure_sign_up_params
+     devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+   end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  def configure_account_update_params
+     devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+   end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -10,7 +10,12 @@
     <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
       <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
     <% end %>
-
+    <%= f.input :first_name %>
+    <%= f.input :last_name %>
+    <%= f.input :suburb %>
+    <%= f.input :dob, start_year: Date.today.year - 100, end_year: Date.today.year - 15%>
+    <%= f.input :phone %>
+    <%= f.input :avatar, as: :file %>
     <%= f.input :password,
                 hint: "leave it blank if you don't want to change it",
                 required: false,
@@ -32,7 +37,7 @@
 <h3>Cancel my account</h3>
 
 <div class="d-flex align-items-center">
-  <div>Unhappy?</div>
+  <div>Unhappy? 💔</div>
   <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete, class: "btn btn-link" %>
 </div>
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -7,7 +7,7 @@
     <%= f.input :first_name %>
     <%= f.input :last_name %>
     <%= f.input :suburb %>
-    <%= f.input :dob, start_year: Date.today.year - 100, end_year: Date.today.year%>
+    <%= f.input :dob, start_year: Date.today.year - 100, end_year: Date.today.year - 15%>
     <%= f.input :phone %>
     <%= f.input :avatar, as: :file %>
     <%= f.input :email,
@@ -21,7 +21,7 @@
     <%= f.input :password_confirmation,
                 required: true,
                 input_html: { autocomplete: "new-password" } %>
-    <%= f.input :partner_email, hint: 'only if your partner is already signed up', label: 'Your Partners Dateful email', error: 'Partners Email not Found' %>%>
+    <%= f.input :partner_email, hint: 'only if your partner is already signed up', label: 'Your Partners Dateful email', error: 'Partners Email not Found' %>
   </div>
 
   <div class="form-actions">


### PR DESCRIPTION
Mostly we hadn't tested new users much, so there was a number of issues
issue 1. A user didn't join a couple correctly and it crashed when you put in your partners email
solution  users now correctly find the partner if they are in the DB or create a new empty couple, they can join an existing couple later using the profile menu

Issue 2. Avatars were not being saved
Solution added in the params for devise to accept avatars.

Issue 3. Users not uploading an avatar crashed the site in a number of places
Solution Users are now given a random avatar if they don't have one already, they can also edit this in the profile menu

Issue 4. users could only change email and password in the profile page
Solution allow users to change any of the existing fields
